### PR TITLE
Trigger rebuild

### DIFF
--- a/.ci_support/linux_64_r_base4.1.yaml
+++ b/.ci_support/linux_64_r_base4.1.yaml
@@ -8,6 +8,8 @@ channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
+cran_mirror:
+- https://cran.r-project.org
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 fortran_compiler:

--- a/.ci_support/linux_64_r_base4.2.yaml
+++ b/.ci_support/linux_64_r_base4.2.yaml
@@ -8,6 +8,8 @@ channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
+cran_mirror:
+- https://cran.r-project.org
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 fortran_compiler:

--- a/.ci_support/osx_64_r_base4.1.yaml
+++ b/.ci_support/osx_64_r_base4.1.yaml
@@ -8,6 +8,8 @@ channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
+cran_mirror:
+- https://cran.r-project.org
 fortran_compiler:
 - gfortran
 fortran_compiler_version:

--- a/.ci_support/osx_64_r_base4.2.yaml
+++ b/.ci_support/osx_64_r_base4.2.yaml
@@ -8,6 +8,8 @@ channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
+cran_mirror:
+- https://cran.r-project.org
 fortran_compiler:
 - gfortran
 fortran_compiler_version:

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -2,6 +2,8 @@ channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
+cran_mirror:
+- https://cran.r-project.org
 m2w64_c_compiler:
 - m2w64-toolchain
 m2w64_fortran_compiler:

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,2 +1,2 @@
-"%R%" CMD INSTALL --build .
-if errorlevel 1 exit 1
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,2 +1,3 @@
 #!/bin/bash
-$R CMD INSTALL --build .
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,33 +9,38 @@ package:
 source:
   fn: geigen_{{ version }}.tar.gz
   url:
-    - https://cran.r-project.org/src/contrib/geigen_{{ version }}.tar.gz
-    - https://cran.r-project.org/src/contrib/Archive/geigen/geigen_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/geigen_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/geigen/geigen_{{ version }}.tar.gz
   sha256: c7ffb869afb8b439a8288addccaa645289b00b12a355f351572b5fc913278f2e
 
 build:
   merge_build_host: True  # [win]
-  number: 5
+  number: 6
   rpaths:
     - lib/R/lib/
     - lib/
 
 requirements:
   build:
-    - posix                # [win]
-    - {{ compiler('fortran') }}        # [unix]
+    - {{ compiler('c') }}              # [not win]
+    - {{ compiler('m2w64_c') }}        # [win]
+    - {{ compiler('fortran') }}        # [not win]
     - {{ compiler('m2w64_fortran') }}  # [win]
-    - {{ compiler('c') }}        # [unix]
-    - {{ compiler('m2w64_c') }}  # [win]
+    - {{ posix }}filesystem            # [win]
+    - {{ posix }}make
+    - {{ posix }}sed                   # [win]
+    - {{ posix }}coreutils             # [win]
+    - {{ posix }}zip                   # [win]
+    - cross-r-base {{ r_base }}        # [build_platform != target_platform]
   host:
     - r-base
-
   run:
     - r-base
+    - {{ native }}gcc-libs             # [win]
 
 test:
   commands:
-    - $R -e "library('geigen')"  # [not win]
+    - $R -e "library('geigen')"           # [not win]
     - "\"%R%\" -e \"library('geigen')\""  # [win]
 
 about:
@@ -45,7 +50,9 @@ about:
     decomposition and the generalized Singular Value Decomposition of a matrix pair,
     using Lapack routines.
   license_family: GPL3
-  license_file: '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-2'
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
The R 4.2 migration somehow did not trigger a package rebuild. This attempts a redo, plus some convention updating while we're at it.

Needed for https://github.com/conda-forge/r-conicfit-feedstock/pull/6

## Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.
